### PR TITLE
Поддержка retina дисплеев + уменьшил ширину бордюра

### DIFF
--- a/paperio/local_runner/game_objects/game.py
+++ b/paperio/local_runner/game_objects/game.py
@@ -14,7 +14,6 @@ from game_objects.bonuses import Nitro, Slowdown, Bonus, Saw
 
 
 class Game:
-    border_color = (144, 163, 174, 255)
     available_bonuses = [b for b in [Nitro, Slowdown, Saw] if b.visio_name in AVAILABLE_BONUSES]
 
     RESULT_LOCATION = os.environ.get('GAME_LOG_LOCATION', './result')
@@ -321,8 +320,6 @@ class Game:
 
 
 class LocalGame(Game):
-    border_color = (144, 163, 174, 255)
-
     def __init__(self, clients, scene, timeout):
         super().__init__(clients)
         self.scene = scene
@@ -367,6 +364,8 @@ class LocalGame(Game):
 
         for player in self.players:
             player.draw_position()
+
+        self.scene.draw_border()
 
         if len(self.players) == 0:
             self.scene.show_game_over()

--- a/paperio/local_runner/game_objects/scene.py
+++ b/paperio/local_runner/game_objects/scene.py
@@ -7,6 +7,7 @@ from helpers import draw_quadrilateral, draw_line
 class Scene:
     background_color = (220 / 255, 240 / 255, 244 / 255, 1)
     border_color = (144, 163, 174, 255)
+    border_width = 2
     game_over_label_color = (95, 99, 104, 255)
 
     leaderboard_color = (255, 255, 255, 128)
@@ -32,7 +33,6 @@ class Scene:
 
     def clear(self):
         self.window.clear()
-        self.draw_border()
 
     def append_label_to_leaderboard(self, label, color):
         if len(self.labels_buffer) > self.leaderboard_rows_count:
@@ -58,10 +58,10 @@ class Scene:
         self.game_over_label.draw()
 
     def draw_border(self):
-        draw_line((0, 0), (0, WINDOW_HEIGHT), self.border_color)
-        draw_line((0, WINDOW_HEIGHT), (WINDOW_WIDTH, WINDOW_HEIGHT), self.border_color)
-        draw_line((WINDOW_WIDTH, WINDOW_HEIGHT), (WINDOW_WIDTH, 0), self.border_color)
-        draw_line((WINDOW_WIDTH, 0), (0, 0), self.border_color)
+        draw_line((0, 0), (0, WINDOW_HEIGHT), self.border_color, self.border_width)
+        draw_line((0, WINDOW_HEIGHT), (WINDOW_WIDTH, WINDOW_HEIGHT), self.border_color, self.border_width)
+        draw_line((WINDOW_WIDTH, WINDOW_HEIGHT), (WINDOW_WIDTH, 0), self.border_color, self.border_width)
+        draw_line((WINDOW_WIDTH, 0), (0, 0), self.border_color, self.border_width)
 
     def draw_leaderboard(self):
         draw_quadrilateral((WINDOW_WIDTH - self.leaderboard_width, WINDOW_HEIGHT - self.leaderboard_height,

--- a/paperio/local_runner/localrunner.py
+++ b/paperio/local_runner/localrunner.py
@@ -68,13 +68,14 @@ class Runner:
 
     @scene.window.event
     def on_resize(width, height):
-        glViewport(0, 0, width, height)
+        (actual_width, actual_height) = scene.window.get_viewport_size()
+        glViewport(0, 0, actual_width, actual_height)
         glMatrixMode(gl.GL_PROJECTION)
         glLoadIdentity()
 
-        factScale = max(WINDOW_WIDTH / width, WINDOW_HEIGHT / height)
-        xMargin = (width * factScale - WINDOW_WIDTH) / 2
-        yMargin = (height * factScale - WINDOW_HEIGHT) / 2
+        factScale = max(WINDOW_WIDTH / actual_width, WINDOW_HEIGHT / actual_height)
+        xMargin = (actual_width * factScale - WINDOW_WIDTH) / 2
+        yMargin = (actual_height * factScale - WINDOW_HEIGHT) / 2
         glOrtho(-xMargin, WINDOW_WIDTH + xMargin, -yMargin, WINDOW_HEIGHT + yMargin, -1, 1)
         glMatrixMode(gl.GL_MODELVIEW)
         return pyglet.event.EVENT_HANDLED


### PR DESCRIPTION
Продолжение https://github.com/MailRuChamps/miniaicups/pull/279

На маке окно выглядит так:
![image](https://user-images.githubusercontent.com/1771387/61675455-162aff80-ad01-11e9-87de-f42eb05486c3.png)

Заюзал scene.window.get_viewport_size(), он возвращает правильные размеры.